### PR TITLE
chore: redirect to storage test

### DIFF
--- a/features/vault.feature
+++ b/features/vault.feature
@@ -1,4 +1,4 @@
-@login_keep_me_signed_in @only
+@login_keep_me_signed_in
 Feature: Vault create and remove
 
   Scenario: Create & Remove Vault


### PR DESCRIPTION
Hey @jarrvis, I've added the redirect test, which will now fail all the time :D It will fail for 2 reasons - one (obvious) because the redirect is not integrated, 2nd - because for some unknown reason the "Storage" is in the &lt;span&gt; tag and not &lt;h2&gt; as for all the other pages (Vault, Notification, Account, etc). I'll open the issue in _akord-web_ as I guess it's better to unify such things